### PR TITLE
Optimize sidebar and links width for small screen

### DIFF
--- a/web/static/css/app/layout.scss
+++ b/web/static/css/app/layout.scss
@@ -259,6 +259,10 @@ input.post-title {
 }
 
 /* Elixir */
+body .content .post-body a {
+  word-break: break-word;
+}
+
 body .content .post-body a,
 body .related-posts li a:hover {
   color: #5E49BA;

--- a/web/static/css/app/sidebar.scss
+++ b/web/static/css/app/sidebar.scss
@@ -7,6 +7,8 @@
  * out above content in mobile and later moves to the side with wider viewports.
  */
 .sidebar {
+  height: 100%;
+  overflow-y: auto;
   text-align: center;
   color: rgba(255,255,255,.5);
   background-color: #432C50;
@@ -159,10 +161,9 @@ a.sidebar-nav-item:focus {
   }
 
   .sidebar-nav-container {
-    position: absolute;
-    right:  1rem;
-    bottom: 1rem;
-    left:   1rem;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid #63407D;
   }
   .sidebar-nav-item.active {
     background: transparent;


### PR DESCRIPTION
2 small improvments:

**Sidebar before**:
![image](https://cloud.githubusercontent.com/assets/464900/10973766/d236a54e-83ac-11e5-990b-f1c9cde76b72.png)

**Sidebar after**:
![untitled48](https://cloud.githubusercontent.com/assets/464900/10973744/b2503fce-83ac-11e5-9ee7-1f2b34822f90.gif)


**Links before**:
![untitled49](https://cloud.githubusercontent.com/assets/464900/10973794/fe749120-83ac-11e5-93c7-baf940935019.gif)

**Links after**:
Well it breaks on every letter to have the exact width, no overflow. I could also use an ellipsis on the overflowing text but I think that it is more useful to have the full link everywhere.


That’s it! Keep up the good work on elixirstatus :+1: 