### PR TITLE
Fix failing test on master

### DIFF
--- a/web/controllers/posting_controller.ex
+++ b/web/controllers/posting_controller.ex
@@ -228,7 +228,7 @@ defmodule ElixirStatus.PostingController do
     %{"title" => title || "", "text" => text || ""}
   end
   defp extract_valid_params(_) do
-    %{}
+    %{"title" => "", "text" => ""}
   end
 
   defp to_create_params(params, conn) do


### PR DESCRIPTION
The extract_valid_params would end up in the empty case and
that means no title or text and regexes against nil don't play
well.

This is a rather quick fix as of now, I think the process
should be aborted more in advance if these parameters are
not there. To that extent I also think it might be worth
going through a basic change set earlier in the process.