### PR TITLE
Correctly render markdown in the formatting help

### DIFF
--- a/web/templates/posting/form.html.eex
+++ b/web/templates/posting/form.html.eex
@@ -50,7 +50,7 @@
         <%= for term <- ["[Link](https://github.com/)", "**bold**", "*italics*", "***highlight***", "`inline code`", "Indent with four spaces to render code blocks:\n\n    # This is rendered as a\n    # code block."] do %>
           <tr>
             <td><pre><%= raw term%></pre></td>
-            <td><%= strip_tags(term) %></td>
+            <td><%= sanitized_markdown(term) %></td>
           </tr>
         <% end %>
       </table>


### PR DESCRIPTION
This is what I originally set out to do :D 

While posting today I noticed that the markdown formatting help wouldn't render correctly:

![selection_010](https://cloud.githubusercontent.com/assets/606517/15830180/422b835c-2c17-11e6-9de1-2cbf29f24484.png)

So I fixed that:

![selection_011](https://cloud.githubusercontent.com/assets/606517/15830203/58756b8c-2c17-11e6-9ba8-6978cd7cdf17.png)

No tests added as there weren't already any acceptance or template tests and it seemed overkill to set them up for just this :)
