### PR TITLE
Require authorisation to connect twitter handle

### DIFF
--- a/web/controllers/twitter_auth_controller.ex
+++ b/web/controllers/twitter_auth_controller.ex
@@ -1,0 +1,23 @@
+defmodule ElixirStatus.TwitterAuthController do
+  use ElixirStatus.Web, :controller
+
+  alias ElixirStatus.User
+
+  plug ElixirStatus.Plugs.LoggedIn when action in [:confirm_handle, :callback]
+
+  def confirm_handle(conn, _params) do
+    token = ExTwitter.request_token()
+    {:ok, authenticate_url} = ExTwitter.authenticate_url(token.oauth_token)
+
+    redirect(conn, external: authenticate_url)
+  end
+
+  def callback(conn, %{"oauth_token" => token, "oauth_verifier" => verifier}) do
+    {:ok, access_token} = ExTwitter.access_token(verifier, token)
+    %{:screen_name => screen_name} = access_token
+    user = Auth.current_user(conn)
+    changeset = User.changeset(user, %{"twitter_handle" => screen_name})
+    Repo.update!(changeset)
+    redirect(conn, to: "/")
+  end
+end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -9,39 +9,26 @@ defmodule ElixirStatus.UserController do
 
   plug ElixirStatus.Plugs.LoggedIn when action in [:edit, :update]
 
-  plug :scrub_params, "user" when action in [:create, :update]
-
   def edit(conn, _) do
     user = Auth.current_user(conn)
     changeset = User.changeset(user)
     render(conn, "edit.html", user: user, changeset: changeset)
   end
 
-  def update(conn, %{"user" => user_params}) do
+  def update(conn, _) do
     user = Auth.current_user(conn)
-    user_params = user_params |> extract_valid_params
-    changeset = User.changeset(user, user_params)
+    changeset = User.changeset(user, %{twitter_handle: nil})
 
     if changeset.valid? do
       Repo.update!(changeset)
 
       conn
-      |> put_flash(:info, "User updated successfully.")
+      |> put_flash(:info, "Disconnected Twitter handle.")
       |> redirect(to: "/")
     else
       Logger.error "POST update_profile: #{inspect(changeset.errors)}"
       render(conn, "edit.html", user: user, changeset: changeset)
     end
-  end
-
-  defp extract_valid_params(%{"twitter_handle" => twitter_handle}) when is_binary(twitter_handle) do
-    %{"twitter_handle" => twitter_handle |> String.replace("@", "")}
-  end
-  defp extract_valid_params(%{"twitter_handle" => nil}) do
-    %{"twitter_handle" => nil}
-  end
-  defp extract_valid_params(_) do
-    %{}
   end
 
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -65,6 +65,8 @@ defmodule ElixirStatus.Router do
     get "/sign_out", GitHubAuthController, :sign_out
     get "/github/callback", GitHubAuthController, :callback
     get "/callback", GitHubAuthController, :callback
+    get "/twitter/confirm", TwitterAuthController, :confirm_handle
+    get "/twitter/callback", TwitterAuthController, :callback
   end
 
   scope "/admin", alias: ElixirStatus.Admin do

--- a/web/templates/posting/form.html.eex
+++ b/web/templates/posting/form.html.eex
@@ -19,7 +19,7 @@
           |
           <a href="<%= edit_user_path(@conn, :edit) %>">Edit your profile</a>
         <% else %>
-          <a href="<%= edit_user_path(@conn, :edit) %>" class="twitter-related"><i class="icon-twitter"></i> Add your Twitter handle</a>
+          <a href="<%= twitter_auth_path(@conn, :confirm_handle) %>" class="twitter-related"><i class="icon-twitter"></i> Add your Twitter handle</a>
         <% end %>
       </span>
     </span>

--- a/web/templates/user/form.html.eex
+++ b/web/templates/user/form.html.eex
@@ -4,16 +4,16 @@
   </div>
   <%= form_for @changeset, @action, fn f -> %>
     <label for="user_twitter_handle">Twitter handle:</label>
-    <%= text_input f, :twitter_handle, id: "user_twitter_handle", class: class_with_error(f, :title, "user-title"), placeholder: "Your Twitter handle goes here (skip the '@')" %>
+    <%= text_input f, :twitter_handle, id: "user_twitter_handle", class: class_with_error(f, :title, "user-title"), placeholder: "Your connected Twitter handle", disabled: "disabled" %>
 
     <div class="post__functions">
       <div>
         <small>
-          If you add your Twitter handle, it will be tweeted alongside your announcement.
+          Your Twitter handle will be mentioned alongside your announcement.
         </small>
 
         <span>
-          <%= submit "Update profile", class: "btn btn--primary" %>
+          <%= submit "Disconnect Twitter handle", class: "btn btn--primary" %>
         </span>
       </div>
     </div>


### PR DESCRIPTION
This fixes #48.

The flow changes a little: when clicking on "Connect Twitter", the user will be sent to twitter. On callback, the handle is read from the response and added to the user info. Tokens are not saved.

The edit user page changes slightly: it doesn't allow the user to set the handle, but instead just allows to disconnect it again.

Thanks @PragTob for guiding me through the process.