### PR TITLE
Use Posting.published/3 when rendering feed

### DIFF
--- a/web/controllers/feed_controller.ex
+++ b/web/controllers/feed_controller.ex
@@ -12,8 +12,10 @@ defmodule ElixirStatus.FeedController do
     |> send_file(200, Avatar.image_path(user_name))
   end
 
-  def rss(conn, _params) do
-    postings = Posting.published
+  def rss(conn, params) do
+    current_user = Auth.current_user(conn)
+    admin? = Auth.admin?(conn)
+    postings = Posting.published(params, current_user, admin?)
     render(conn, "rss.xml", postings: postings.entries)
   end
 end


### PR DESCRIPTION
Use changes introduced by bbac7b7892cf823adc9f9ba656deb93e9252b8d1. Should fix #54.

I also found that [`ElixirStatus.Admin.PostingController.index/2`](https://github.com/rrrene/elixirstatus-web/blob/master/web/controllers/admin/posting_controller.ex#L12) and [`ElixirStatus.Admin.OverviewController.index/2`](https://github.com/rrrene/elixirstatus-web/blob/master/web/controllers/admin/overview_controller.ex#L11) use `ElixirStatus.Persistence.Posting.published/1` which doesn't seem to exist, should I change these as well?