### PR TITLE
Use canonical URLs to manage search engine indexes

### DIFF
--- a/web/controllers/posting_controller.ex
+++ b/web/controllers/posting_controller.ex
@@ -26,6 +26,13 @@ defmodule ElixirStatus.PostingController do
     admin? = Auth.admin?(conn)
     page = ElixirStatus.Persistence.Posting.published(params, current_user, admin?)
 
+    canonical_params = Enum.filter(params, fn
+      {"ref", _} -> false
+      {"just_signed_in", _} -> false
+      _ -> true
+    end)
+    canonical_url = posting_url(:index, canonical_params)
+
     assigns =
       [
         postings: page.entries,
@@ -39,7 +46,8 @@ defmodule ElixirStatus.PostingController do
         current_posting_filter: params["filter"] |> nil_if_empty(),
         posting_filters: @posting_filters,
         search: params["q"] |> nil_if_empty(),
-        changeset: changeset()
+        changeset: changeset(),
+        canonical_url: canonical_url,
       ]
 
     conn

--- a/web/controllers/posting_controller.ex
+++ b/web/controllers/posting_controller.ex
@@ -31,7 +31,7 @@ defmodule ElixirStatus.PostingController do
       {"just_signed_in", _} -> false
       _ -> true
     end)
-    canonical_url = posting_url(:index, canonical_params)
+    canonical_url = posting_url(conn, :index, canonical_params)
 
     assigns =
       [

--- a/web/router.ex
+++ b/web/router.ex
@@ -27,12 +27,6 @@ defmodule ElixirStatus.Router do
     plug :assign_current_user
   end
 
-  scope "/embed", ElixirStatus do
-    pipe_through :embedded
-
-    get "/", PostingController, :index
-  end
-
   scope "/", ElixirStatus do
     pipe_through :browser # Use the default browser stack
 
@@ -57,6 +51,12 @@ defmodule ElixirStatus.Router do
     put "/reset_twitter_handle", UserController, :reset_twitter_handle, as: :reset_twitter_handle
 
     get "/=:uid", ShortLinkController, :show
+  end
+
+  scope "/embed", ElixirStatus do
+    pipe_through :embedded
+
+    get "/", PostingController, :index
   end
 
   scope "/auth", alias: ElixirStatus do

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -9,7 +9,7 @@
     <%= if logged_in?(@conn) do %>
       <meta name="logged_in_as" content="<%= @current_user.user_name %>">
     <% end %>
-    <%= if @canonical_url do %>
+    <%= if assigns[:canonical_url] do %>
       <link rel="canonical" href="<%= @canonical_url %>">
     <% end %>
     <meta property="og:image" content="<%= og_image_url(assigns) %>" />

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -9,6 +9,9 @@
     <%= if logged_in?(@conn) do %>
       <meta name="logged_in_as" content="<%= @current_user.user_name %>">
     <% end %>
+    <%= if @canonical_url do %>
+      <link rel="canonical" href="<%= @canonical_url %>">
+    <% end %>
     <meta property="og:image" content="<%= og_image_url(assigns) %>" />
 
     <title><%= html_title(assigns) %></title>


### PR DESCRIPTION
We do not want Google to serve up a search result with `?ref=elixirweekly` in the URL, firstly because that's false (it's not an EW referral if a SERP provides it) and secondly because it splits ElixirStatus's Google juice between two identical pages.