### PR TITLE
Autogenerate IDs for users

### DIFF
--- a/priv/repo/seeds/users_dev.exs
+++ b/priv/repo/seeds/users_dev.exs
@@ -3,63 +3,54 @@ alias ElixirStatus.Repo
 
 all = [
   %User{
-    id: 1,
     full_name: "René Föhring",
     user_name: "rrrene",
     email: "rrrene@example.com",
     provider: "github"
   },
   %User{
-    id: 2,
     full_name: "",
     user_name: "rizafahmi",
     email: "rizafahmi@example.com",
     provider: "github"
   },
   %User{
-    id: 3,
     full_name: "",
     user_name: "joekain",
     email: "joekain@example.com",
     provider: "github"
   },
   %User{
-    id: 4,
     full_name: "",
     user_name: "michalmuskala",
     email: "michalmuskala@example.com",
     provider: "github"
   },
   %User{
-    id: 5,
     full_name: "Hans",
     user_name: "Hanspagh",
     email: "Hanspagh@example.com",
     provider: "github"
   },
   %User{
-    id: 6,
     full_name: "",
     user_name: "h4cc",
     email: "h4cc@example.com",
     provider: "github"
   },
   %User{
-    id: 7,
     full_name: "",
     user_name: "philnash",
     email: "philnash@example.com",
     provider: "github"
   },
   %User{
-    id: 8,
     full_name: "",
     user_name: "nithinbekal",
     email: "nithinbekal@example.com",
     provider: "github"
   },
   %User{
-    id: 100,
     full_name: "",
     user_name: "your-name-here",
     email: "your-name-here@example.com",


### PR DESCRIPTION
Hello,

this PR will fix a Primary Key constraint violation cause by the seed for development environment.

We simply removed the value for the field `id` so that Ecto will use the correct way to generate the `autoincrement` value.

Joe.