### PR TITLE
Add web app manifest

### DIFF
--- a/priv/static/manifest.json
+++ b/priv/static/manifest.json
@@ -1,0 +1,15 @@
+{
+    "name": "ElixirStatus",
+    "short_name": "ElixirStatus",
+    "description": "Community site for Elixir projects, blog posts, and updates",
+    "start_url": ".",
+    "scope": "/",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#2e2148",
+    "icons": [
+        "src": "images/logo.png",
+        "sizes": "256x256",
+        "type": "image/png"
+    ]
+}

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -13,6 +13,7 @@
 
     <title><%= html_title(assigns) %></title>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
+    <link rel="manifest" href="<%= static_path(@conn, "/manifest.json") %>">
 
     <%= render ElixirStatus.SharedView, "cookieconsent.html", conn: @conn %>
   </head>


### PR DESCRIPTION
This PR adds a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest). This provides a nicer experience in supporting browsers, which allows users to add the site to their homescreen/desktop for easier access.